### PR TITLE
Backport http keep-alive configuration to enable EventSource reconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "aedes": "^0.51.0",
         "bonjour-service": "^1.2.1",
         "eventsource": "^2.0.2",
-        "mqtt": "^5.5.3"
+        "mqtt": "^5.5.3",
+        "semver": "^7.6.0"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^1.7.2",
@@ -2992,7 +2993,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3718,7 +3718,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4473,8 +4472,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "aedes": "^0.51.0",
     "bonjour-service": "^1.2.1",
     "eventsource": "^2.0.2",
-    "mqtt": "^5.5.3"
+    "mqtt": "^5.5.3",
+    "semver": "^7.6.0"
   }
 }


### PR DESCRIPTION
Node.js v19 changed the default configuration of the built-in http agent used by EventSource to connect to Server Sent Events from ESPHome.  Agents before this change did not use sockets with keep-alive enabled, preventing `EventSource` from detecting disruptions to the connection it uses to receive events.

Currently, the official homebridge docker container is based on Node.js v18, so this is likely to affect a large number of HBR users.

This change will detect if the node version is old enough not to have this behavior and configure the http (and https) modules to match behavior from more recent Node.js versions.