### PR TITLE
Konnected GDO Tweaks

### DIFF
--- a/src/ratgdo-platform.ts
+++ b/src/ratgdo-platform.ts
@@ -10,7 +10,6 @@ import { PLATFORM_NAME, PLUGIN_NAME, RATGDO_AUTODISCOVERY_INTERVAL, RATGDO_AUTOD
 import { RatgdoOptions, featureOptionCategories, featureOptions } from "./ratgdo-options.js";
 import EventSource from "eventsource";
 import { RatgdoAccessory } from "./ratgdo-device.js";
-import { RatgdoVariant } from "./ratgdo-types.js";
 import http from "node:http";
 import net from "node:net";
 import util from "node:util";
@@ -339,7 +338,7 @@ export class RatgdoPlatform implements DynamicPlatformPlugin {
       firmwareVersion: deviceInfo.version ?? deviceInfo.esphome_version,
       mac: mac.replace(/:/g, ""),
       name: deviceInfo.friendly_name,
-      variant: deviceInfo.project_name.includes(RatgdoVariant.KONNECTED) ? RatgdoVariant.KONNECTED : RatgdoVariant.RATGDO
+      variant: deviceInfo.project_name
     };
 
     // Inform the user that we've discovered a device.

--- a/src/ratgdo-platform.ts
+++ b/src/ratgdo-platform.ts
@@ -13,6 +13,7 @@ import { RatgdoAccessory } from "./ratgdo-device.js";
 import http from "node:http";
 import net from "node:net";
 import util from "node:util";
+import { RatgdoVariant } from "./ratgdo-types.js";
 
 export class RatgdoPlatform implements DynamicPlatformPlugin {
 
@@ -335,10 +336,10 @@ export class RatgdoPlatform implements DynamicPlatformPlugin {
     const device = {
 
       address: address,
-      firmwareVersion: deviceInfo.version,
+      firmwareVersion: deviceInfo.version || deviceInfo.esphome_version,
       mac: mac.replace(/:/g, ""),
       name: deviceInfo.friendly_name,
-      variant: deviceInfo.project_name
+      variant: deviceInfo.project_name.includes(RatgdoVariant.KONNECTED) ? RatgdoVariant.KONNECTED : RatgdoVariant.RATGDO
     };
 
     // Inform the user that we've discovered a device.

--- a/src/ratgdo-platform.ts
+++ b/src/ratgdo-platform.ts
@@ -336,7 +336,7 @@ export class RatgdoPlatform implements DynamicPlatformPlugin {
     const device = {
 
       address: address,
-      firmwareVersion: deviceInfo.version || deviceInfo.esphome_version,
+      firmwareVersion: deviceInfo.version ?? deviceInfo.esphome_version,
       mac: mac.replace(/:/g, ""),
       name: deviceInfo.friendly_name,
       variant: deviceInfo.project_name.includes(RatgdoVariant.KONNECTED) ? RatgdoVariant.KONNECTED : RatgdoVariant.RATGDO

--- a/src/ratgdo-platform.ts
+++ b/src/ratgdo-platform.ts
@@ -10,10 +10,10 @@ import { PLATFORM_NAME, PLUGIN_NAME, RATGDO_AUTODISCOVERY_INTERVAL, RATGDO_AUTOD
 import { RatgdoOptions, featureOptionCategories, featureOptions } from "./ratgdo-options.js";
 import EventSource from "eventsource";
 import { RatgdoAccessory } from "./ratgdo-device.js";
+import { RatgdoVariant } from "./ratgdo-types.js";
 import http from "node:http";
 import net from "node:net";
 import util from "node:util";
-import { RatgdoVariant } from "./ratgdo-types.js";
 
 export class RatgdoPlatform implements DynamicPlatformPlugin {
 

--- a/src/ratgdo-types.ts
+++ b/src/ratgdo-types.ts
@@ -31,6 +31,6 @@ export enum RatgdoReservedNames {
 // Ratgdo device variants.
 export enum RatgdoVariant {
 
-  KONNECTED = "konnected.garage-door",
+  KONNECTED = "konnected.garage-door-gdov2-q",
   RATGDO = "ratgdo.esphome"
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,7 +14,7 @@ export const PLUGIN_NAME = "homebridge-ratgdo";
 export const RATGDO_AUTODISCOVERY_INTERVAL = 60;
 
 // mDNS TXT record project name associated with a Ratgdo device.
-export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] = [ RatgdoVariant.KONNECTED, RatgdoVariant.RATGDO ];
+export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] = [ `${RatgdoVariant.KONNECTED}-gdov1-s`, `${RatgdoVariant.KONNECTED}-gdov2-q`, `${RatgdoVariant.KONNECTED}-gdov2-s`, RatgdoVariant.RATGDO ];
 
 // mDNS service types associated with a Ratgdo device.
 export const RATGDO_AUTODISCOVERY_TYPES = [ "esphomelib", "konnected" ];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,12 +13,8 @@ export const PLUGIN_NAME = "homebridge-ratgdo";
 // Interval, in seconds, to initiate mDNS discovery requests for new Ratgdo devices.
 export const RATGDO_AUTODISCOVERY_INTERVAL = 60;
 
-// Separate Konnected RATGDO variant project names
-export const KONNECTED_VARIANT_PROJECT_NAMES: string[] = [];
-
 // mDNS TXT record project name associated with a Ratgdo device.
-export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] =
-  [ RatgdoVariant.KONNECTED + "-gdov1-s", RatgdoVariant.KONNECTED + "-gdov2-q", RatgdoVariant.KONNECTED + "-gdov2-s", RatgdoVariant.RATGDO ];
+export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] = [ RatgdoVariant.KONNECTED, RatgdoVariant.RATGDO ];
 
 // mDNS service types associated with a Ratgdo device.
 export const RATGDO_AUTODISCOVERY_TYPES = [ "esphomelib", "konnected" ];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,13 +13,12 @@ export const PLUGIN_NAME = "homebridge-ratgdo";
 // Interval, in seconds, to initiate mDNS discovery requests for new Ratgdo devices.
 export const RATGDO_AUTODISCOVERY_INTERVAL = 60;
 
+// Separate Konnected RATGDO variant project names
+export const KONNECTED_VARIANT_PROJECT_NAMES: string[] = [];
+
 // mDNS TXT record project name associated with a Ratgdo device.
-export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] = [
-  `${RatgdoVariant.KONNECTED}-gdov1-s`,
-  `${RatgdoVariant.KONNECTED}-gdov2-q`,
-  `${RatgdoVariant.KONNECTED}-gdov2-s`,
-  RatgdoVariant.RATGDO
-];
+export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] =
+  [ RatgdoVariant.KONNECTED + "-gdov1-s", RatgdoVariant.KONNECTED + "-gdov2-q", RatgdoVariant.KONNECTED + "-gdov2-s", RatgdoVariant.RATGDO ];
 
 // mDNS service types associated with a Ratgdo device.
 export const RATGDO_AUTODISCOVERY_TYPES = [ "esphomelib", "konnected" ];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,7 +14,12 @@ export const PLUGIN_NAME = "homebridge-ratgdo";
 export const RATGDO_AUTODISCOVERY_INTERVAL = 60;
 
 // mDNS TXT record project name associated with a Ratgdo device.
-export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] = [ `${RatgdoVariant.KONNECTED}-gdov1-s`, `${RatgdoVariant.KONNECTED}-gdov2-q`, `${RatgdoVariant.KONNECTED}-gdov2-s`, RatgdoVariant.RATGDO ];
+export const RATGDO_AUTODISCOVERY_PROJECT_NAMES: string[] = [
+  `${RatgdoVariant.KONNECTED}-gdov1-s`,
+  `${RatgdoVariant.KONNECTED}-gdov2-q`,
+  `${RatgdoVariant.KONNECTED}-gdov2-s`,
+  RatgdoVariant.RATGDO
+];
 
 // mDNS service types associated with a Ratgdo device.
 export const RATGDO_AUTODISCOVERY_TYPES = [ "esphomelib", "konnected" ];


### PR DESCRIPTION
The project_name for connected GDOs has 3 possible values
The service `version` field is called `esphome_version` on Konnected GDOs