### PR TITLE
Fix duplicate door commands stopping the opener during transitions

### DIFF
--- a/src/ratgdo-device.ts
+++ b/src/ratgdo-device.ts
@@ -961,7 +961,18 @@ export class RatgdoAccessory {
       return false;
     }
 
-    // If we are already opening or closing the garage door, we assume the user wants to stop the garage door opener at it's current location.
+    // If the door is already transitioning toward the requested state, ignore the duplicate command. This prevents a common issue with HomeKit automations where
+    // multiple triggers (e.g. two family members arriving home simultaneously) send rapid open commands, causing the second command to be misinterpreted as a stop.
+    if((this.status.door === this.hap.Characteristic.CurrentDoorState.OPENING && value === this.hap.Characteristic.TargetDoorState.OPEN) ||
+      (this.status.door === this.hap.Characteristic.CurrentDoorState.CLOSING && value === this.hap.Characteristic.TargetDoorState.CLOSED)) {
+
+      this.log.info("Ignoring duplicate %s command - door is already %s.", this.translateTargetDoorState(value),
+        this.status.door === this.hap.Characteristic.CurrentDoorState.OPENING ? "opening" : "closing");
+
+      return true;
+    }
+
+    // If we are already opening or closing the garage door in the opposite direction, we assume the user wants to stop the garage door opener at it's current location.
     if((this.status.door === this.hap.Characteristic.CurrentDoorState.OPENING) || (this.status.door === this.hap.Characteristic.CurrentDoorState.CLOSING)) {
 
       this.log.debug("User-initiated stop requested while transitioning between open and close states.");


### PR DESCRIPTION
## Summary

When the garage door is already transitioning toward the requested state (e.g., opening and another `open` command arrives), the duplicate command is now ignored instead of being treated as a stop request.

- Adds a check before the existing stop logic in `setDoorState()` to detect when the door is already moving in the requested direction
- Preserves the existing stop behavior when the door is transitioning in the *opposite* direction

## Problem

We ran into this using `Enable.Opener.Switch` with an Apple Home "anyone arrives" geofence automation. When two family members arrive home at the same time, both automations fire and send `open` commands in quick succession. The current code treats *any* command received during a transition as a stop request ([ratgdo-device.ts L964-972](https://github.com/hjdhjd/homebridge-ratgdo/blob/ca39fbb/src/ratgdo-device.ts#L964-L972)), so the second `open` stops the door mid-travel — leaving the garage partially open.

This is a common scenario since the automation switch exists specifically to bypass HomeKit's secure accessory authentication for hands-free operation, and geofence automations are a primary use case.

## Fix

Before the existing transition/stop check, we now compare the current transition direction against the requested state:

- **Opening + open command** → ignore (already doing what was asked)
- **Closing + close command** → ignore (already doing what was asked)  
- **Opening + close command** → stop (existing behavior, preserved)
- **Closing + open command** → stop (existing behavior, preserved)

## Test plan

- [ ] Verify sending `open` while door is opening does **not** stop the door
- [ ] Verify sending `close` while door is closing does **not** stop the door
- [ ] Verify sending `close` while door is opening **does** stop the door
- [ ] Verify sending `open` while door is closing **does** stop the door
- [ ] Verify normal open/close from idle state still works
- [ ] Verify the automation opener switch, dimmer, and GarageDoorOpener service all use `setDoorState()` and benefit from this fix